### PR TITLE
Making SSR compatible

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
             {
                 test: /\.jsx?$/,
                 exclude: [
-                  path.resolve(__dirname, "node_modules")
+                    path.resolve(__dirname, "node_modules")
                 ],
                 use: [{loader: "babel-loader"}]
             }
@@ -24,7 +24,8 @@ module.exports = {
         publicPath: "/",
         filename: "column-resizer.js",
         libraryTarget: "umd",
-        library: "ColumnResizer"
+        library: "ColumnResizer",
+        globalObject: "this"
     },
     optimization: {
         nodeEnv: 'production',
@@ -37,7 +38,8 @@ module.exports = {
                         warnings: false
                     },
                     mangle: {
-                        keep_fnames: true                    },
+                        keep_fnames: true 
+                    },
                     output: {
                         comments: false
                     }


### PR DESCRIPTION
# Description
* Adding `globalObject` to webpack config to `this` is used instead of `window`

Fixes #13 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Test A; Ran existing unit tests -- all pass
- [x] Test B; Tested locally with gatsby and I was able to build

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works **not applicable**
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
